### PR TITLE
Add support for Fuel's Query::cached()

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -216,22 +216,22 @@ class Query
 		return $this;
 	}
 
-    /**
-     * Enables the query to be cached for a specified amount of time.
-     *
-     * @param   integer $lifetime  number of seconds to cache or null for default
-     * @param   string  $cache_key name of the cache key to be used or null for default
-     * @param   boolean $cache_all if true, cache all results, even empty ones
-     *
-     * @return  $this
-     */
+	/**
+	 * Enables the query to be cached for a specified amount of time.
+	 *
+	 * @param   integer $lifetime  number of seconds to cache or null for default
+	 * @param   string  $cache_key name of the cache key to be used or null for default
+	 * @param   boolean $cache_all if true, cache all results, even empty ones
+	 *
+	 * @return  $this
+	 */
 	public function query_cache($lifetime = null, $cache_key = null, $cache_all = true)
 	{
-        $this->query_cache['lifetime'] = $lifetime === true ? \Config::get('novius-os.cache_duration_page') : $lifetime;
-        $this->query_cache['cache_all'] = (bool)$cache_all;
-        is_string($cache_key) and $this->query_cache['cache_key'] = $cache_key;
+		$this->query_cache['lifetime'] = $lifetime === true ? \Config::get('novius-os.cache_duration_query', 0) : $lifetime;
+		$this->query_cache['cache_all'] = (bool)$cache_all;
+		is_string($cache_key) and $this->query_cache['cache_key'] = $cache_key;
 
-        return $this;
+		return $this;
 	}
 
 	/**
@@ -1232,13 +1232,14 @@ class Query
 			}
 		}
 
-        if (is_array($this->query_cache) && \Arr::get($this->query_cache, 'lifetime', null)) {
-            $query = $query->cached(
-                \Arr::get($this->query_cache, 'lifetime', null),
-                \Arr::get($this->query_cache, 'cache_key', null),
-                \Arr::get($this->query_cache, 'cache_all', null)
-            );
-        }
+		if (is_array($this->query_cache) && \Arr::get($this->query_cache, 'lifetime', null))
+		{
+			$query = $query->cached(
+				\Arr::get($this->query_cache, 'lifetime', null),
+				\Arr::get($this->query_cache, 'cache_key', null),
+				\Arr::get($this->query_cache, 'cache_all', null)
+			);
+		}
 		$rows = $query->execute($this->connection)->as_array();
 		$result = array();
 		$model = $this->model;

--- a/classes/query.php
+++ b/classes/query.php
@@ -219,7 +219,7 @@ class Query
 	/**
 	 * Enables the query to be cached for a specified amount of time.
 	 *
-	 * @param   integer $lifetime  number of seconds to cache or null for default
+	 * @param   integer $lifetime  number of seconds to cache or null for default, false will skip requesting a cache
 	 * @param   string  $cache_key name of the cache key to be used or null for default
 	 * @param   boolean $cache_all if true, cache all results, even empty ones
 	 *
@@ -227,7 +227,7 @@ class Query
 	 */
 	public function query_cache($lifetime = null, $cache_key = null, $cache_all = true)
 	{
-		$this->query_cache['lifetime'] = $lifetime === true ? \Config::get('novius-os.cache_duration_query', 0) : $lifetime;
+		$this->query_cache['lifetime']  = $lifetime;
 		$this->query_cache['cache_all'] = (bool)$cache_all;
 		is_string($cache_key) and $this->query_cache['cache_key'] = $cache_key;
 
@@ -1232,12 +1232,12 @@ class Query
 			}
 		}
 
-		if (is_array($this->query_cache) && \Arr::get($this->query_cache, 'lifetime', null))
+		if (\Arr::get($this->query_cache, 'lifetime', false) !== false)
 		{
 			$query = $query->cached(
 				\Arr::get($this->query_cache, 'lifetime', null),
 				\Arr::get($this->query_cache, 'cache_key', null),
-				\Arr::get($this->query_cache, 'cache_all', null)
+				\Arr::get($this->query_cache, 'cache_all', true)
 			);
 		}
 		$rows = $query->execute($this->connection)->as_array();


### PR DESCRIPTION
This adds a new method query_cache that will pass through to cached(), same api.  
Passing true will fetch page's duration from the app config as default lifetime.
