### PR TITLE
Implements an order field in the many_many relation + unifies the implementation of conditions

### DIFF
--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -79,54 +79,139 @@ class ManyMany extends Relation
 			throw new \FuelException('Related model not found by Many_Many relation "'.$this->name.'": '.$this->model_to);
 		}
 		$this->model_to = get_real_class($this->model_to);
+
+		$this->key_through_order = \Arr::get($config, 'key_through_order');
 	}
 
+	/**
+	 * Gets the related items for the item $from
+	 *
+	 * @param Model $from
+	 * @param array $conditions
+	 * @return array|object
+	 */
 	public function get(Model $from, array $conditions = array())
 	{
-		// Create the query on the model_through
+		$alias_to = 't0';
+
+		// Merges the conditions of the relation with the specific conditions
+		$conditions = \Arr::merge($this->conditions, $conditions);
+
+		// Creates the query on the model_through
 		$query = call_user_func(array($this->model_to, 'query'));
 
-		// set the model_from's keys as where conditions for the model_through
-		$join = array(
-				'table'      => array($this->table_through, 't0_through'),
-				'join_type'  => null,
-				'join_on'    => array(),
-				'columns'    => $this->select_through('t0_through')
-		);
-
-		reset($this->key_from);
-		foreach ($this->key_through_from as $key)
-		{
-			if ($from->{current($this->key_from)} === null)
-			{
-				return array();
-			}
-			$query->where('t0_through.'.$key, $from->{current($this->key_from)});
-			next($this->key_from);
+		// Builds the join on the table through
+		if (!$this->_query_build_join($query, $conditions, $alias_to, $from)) {
+			return array();
 		}
 
+		// Builds the where conditions
+		if (!$this->_query_build_where($query, $conditions, $alias_to, $from)) {
+			return array();
+		}
+
+		// Builds the order_by conditions
+		if (!$this->_query_build_orderby($query, $conditions, $alias_to, $from)) {
+			return array();
+		}
+
+		return $query->get();
+	}
+
+	/**
+	 * Builds the join on the table through for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return array
+	 */
+	protected function _query_build_join($query, $conditions, $alias_to, $model_from)
+	{
+		$join = array(
+			'table'      => array($this->table_through, $alias_to.'_through'),
+			'join_type'  => null,
+			'join_on'    => array(),
+			'columns'    => $this->select_through($alias_to.'_through')
+		);
+
+		// Creates the native conditions on the join
 		reset($this->key_to);
 		foreach ($this->key_through_to as $key)
 		{
-			$join['join_on'][] = array('t0_through.'.$key, '=', 't0.'.current($this->key_to));
+			$join['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
 			next($this->key_to);
 		}
 
-        foreach (\Arr::get($this->conditions, 'through_where', array()) as $key => $condition)
-        {
-            is_array($condition) or $condition = array($key, '=', $condition);
-            $condition[0] = 't0_through.'.$condition[0];
-            $query->where($condition);
-        }
+		// Creates the custom conditions on the join
+		foreach (\Arr::get($conditions, 'join_on', array()) as $key => $condition) {
+			is_array($condition) or $condition = array($key, '=', $condition);
+			reset($condition);
+			$condition[key($condition)] = $alias_to.'_through.'.current($condition);
+			$join['join_on'][] = $condition;
+		}
 
-        $conditions = \Arr::merge($this->conditions, $conditions);
+		// Creates the join on the query
+		$query->_join($join);
 
-        foreach (\Arr::get($conditions, 'where', array()) as $key => $condition)
+		return true;
+	}
+
+	/**
+	 * Builds the where conditions for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return bool
+	 */
+	protected function _query_build_where($query, $conditions, $alias_to, $model_from)
+	{
+		// Creates the native conditions on the query
+		reset($this->key_from);
+		foreach ($this->key_through_from as $key)
+		{
+			if ($model_from->{current($this->key_from)} === null)
+			{
+				return false;
+			}
+			$query->where($alias_to.'_through.'.$key, $model_from->{current($this->key_from)});
+			next($this->key_from);
+		}
+
+		// Creates the custom conditions related to the table through on the query
+		foreach (\Arr::get($conditions, 'through_where', array()) as $key => $condition)
 		{
 			is_array($condition) or $condition = array($key, '=', $condition);
+			$condition[0] = $alias_to.'_through.'.$condition[0];
 			$query->where($condition);
 		}
 
+		// Creates the custom conditions on the query
+		foreach (\Arr::get($conditions, 'where', array()) as $key => $condition)
+		{
+			is_array($condition) or $condition = array($key, '=', $condition);
+			$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+			$query->where($condition);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the order_by conditions for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return bool
+	 */
+	protected function _query_build_orderby($query, $conditions, $alias_to, $model_from)
+	{
+		// Creates the custom order_by conditions on the query
 		foreach (\Arr::get($conditions, 'order_by', array()) as $field => $direction)
 		{
 			if (is_numeric($field))
@@ -135,15 +220,172 @@ class ManyMany extends Relation
 			}
 			else
 			{
+				$field = $this->getAliasedField($field, $alias_to);
 				$query->order_by($field, $direction);
 			}
 		}
 
-		$query->_join($join);
-
-		return $query->get();
+		return true;
 	}
 
+	/**
+	 * Gets the properties to join the related items for a query
+	 *
+	 * @param $alias_from
+	 * @param $rel_name
+	 * @param $alias_to_nr
+	 * @param array $conditions
+	 * @return array
+	 */
+	public function join($alias_from, $rel_name, $alias_to_nr, $conditions = array())
+	{
+		$alias_to = 't'.$alias_to_nr;
+
+		// Merges the conditions of the relation with the specific conditions
+		$conditions = \Arr::merge($this->conditions, $conditions);
+
+		// Creates the joins to the model_to
+		$models = array(
+			$rel_name.'_through' => array(
+				'model'        => null,
+				'connection'   => call_user_func(array($this->model_to, 'connection',)),
+				'table'        => array($this->table_through, $alias_to.'_through'),
+				'primary_key'  => null,
+				'join_type'    => \Arr::get($conditions, 'join_type', 'left'),
+				'join_on'      => array(),
+				'columns'      => $this->select_through($alias_to.'_through'),
+				'rel_name'     => $this->model_through,
+				'relation'     => $this
+			),
+			$rel_name => array(
+				'model'        => $this->model_to,
+				'connection'   => call_user_func(array($this->model_to, 'connection')),
+				'table'        => array(call_user_func(array($this->model_to, 'table')), $alias_to),
+				'primary_key'  => call_user_func(array($this->model_to, 'primary_key')),
+				'join_type'    => \Arr::get($conditions, 'join_type', 'left'),
+				'join_on'      => array(),
+				'columns'      => $this->select($alias_to),
+				'rel_name'     => strpos($rel_name, '.') ? substr($rel_name, strrpos($rel_name, '.') + 1) : $rel_name,
+				'relation'     => $this,
+				'where'        => \Arr::get($conditions, 'where', array()),
+			)
+		);
+
+		// Builds the join conditions
+		if (!$this->_join_build_join($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the where conditions
+		if (!$this->_join_build_where($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the order_by conditions
+		if (!$this->_join_build_orderby($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		return $models;
+	}
+
+	/**
+	 * Builds the join conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_join(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Creates the native conditions on the joins
+		reset($this->key_from);
+		foreach ($this->key_through_from as $key)
+		{
+			$models[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'_through.'.$key);
+			next($this->key_from);
+		}
+		reset($this->key_to);
+		foreach ($this->key_through_to as $key)
+		{
+			$models[$rel_name]['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
+			next($this->key_to);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the where conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_where(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Creates the custom conditions on the table_through join
+		foreach (\Arr::get($conditions, 'through_where', array()) as $key => $condition)
+		{
+			! is_array($condition) and $condition = array($key, '=', $condition);
+			is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
+			$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+			$models[$rel_name.'_through']['join_on'][] = $condition;
+		}
+
+		// Creates the custom conditions on the model_to join
+		foreach (\Arr::get($conditions, array('where', 'join_on')) as $where)
+		{
+			foreach ($where as $key => $condition)
+			{
+				! is_array($condition) and $condition = array($key, '=', $condition);
+				is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
+				$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+				$models[$rel_name]['join_on'][] = $condition;
+			}
+		}
+
+
+		return true;
+	}
+
+	/**
+	 * Builds the order_by conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_orderby(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Builds the order_by conditions
+		foreach (\Arr::get($conditions, 'order_by', array()) as $key => $direction)
+		{
+			$key = $this->getAliasedField($key, $alias_to);
+			$models[$rel_name]['order_by'][$key] = $direction;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the columns to select through a table
+	 *
+	 * @param $table
+	 * @return array
+	 */
 	public function select_through($table)
 	{
 		foreach ($this->key_through_to as $to)
@@ -158,100 +400,16 @@ class ManyMany extends Relation
 		return $properties;
 	}
 
-	public function join($alias_from, $rel_name, $alias_to_nr, $conditions = array())
-	{
-		$alias_to = 't'.$alias_to_nr;
-
-		$alias_through = array($this->table_through, $alias_to.'_through');
-		$alias_to_table = array(call_user_func(array($this->model_to, 'table')), $alias_to);
-
-		$models = array(
-			$rel_name.'_through' => array(
-				'model'        => null,
-				'connection'   => call_user_func(array($this->model_to, 'connection')),
-				'table'        => $alias_through,
-				'primary_key'  => null,
-				'join_type'    => \Arr::get($conditions, 'join_type') ?: \Arr::get($this->conditions, 'join_type', 'left'),
-				'join_on'      => array(),
-				'columns'      => $this->select_through($alias_to.'_through'),
-				'rel_name'     => $this->model_through,
-				'relation'     => $this
-			),
-			$rel_name => array(
-				'model'        => $this->model_to,
-				'connection'   => call_user_func(array($this->model_to, 'connection')),
-				'table'        => $alias_to_table,
-				'primary_key'  => call_user_func(array($this->model_to, 'primary_key')),
-				'join_type'    => \Arr::get($conditions, 'join_type') ?: \Arr::get($this->conditions, 'join_type', 'left'),
-				'join_on'      => array(),
-				'columns'      => $this->select($alias_to),
-				'rel_name'     => strpos($rel_name, '.') ? substr($rel_name, strrpos($rel_name, '.') + 1) : $rel_name,
-				'relation'     => $this,
-				'where'        => \Arr::get($conditions, 'where', array()),
-			)
-		);
-
-		reset($this->key_from);
-		foreach ($this->key_through_from as $key)
-		{
-			$models[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'_through.'.$key);
-			next($this->key_from);
-		}
-
-		reset($this->key_to);
-		foreach ($this->key_through_to as $key)
-		{
-			$models[$rel_name]['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
-			next($this->key_to);
-		}
-
-        foreach (array(\Arr::get($this->conditions, 'through_where', array()), \Arr::get($conditions, 'through_where', array())) as $c)
-        {
-            foreach ($c as $key => $condition)
-            {
-                ! is_array($condition) and $condition = array($key, '=', $condition);
-                if ( ! $condition[0] instanceof \Fuel\Core\Database_Expression and strpos($condition[0], '.') === false)
-                {
-                    $condition[0] = $alias_to.'_through'.'.'.$condition[0];
-                }
-                is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
-
-                $models[$rel_name.'_through']['join_on'][] = $condition;
-            }
-        }
-
-		foreach (array(\Arr::get($this->conditions, 'where', array()), \Arr::get($conditions, 'join_on', array())) as $c)
-		{
-			foreach ($c as $key => $condition)
-			{
-				! is_array($condition) and $condition = array($key, '=', $condition);
-				if ( ! $condition[0] instanceof \Fuel\Core\Database_Expression and strpos($condition[0], '.') === false)
-				{
-					$condition[0] = $alias_to.'.'.$condition[0];
-				}
-				is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
-
-				$models[$rel_name]['join_on'][] = $condition;
-			}
-		}
-
-		$order_by = \Arr::get($conditions, 'order_by') ?: \Arr::get($this->conditions, 'order_by', array());
-		foreach ($order_by as $key => $direction)
-		{
-			if ( ! $key instanceof \Fuel\Core\Database_Expression and strpos($key, '.') === false)
-			{
-				$key = $alias_to.'.'.$key;
-			}
-			else
-			{
-				$key = str_replace(array($alias_through[0],$alias_to_table[0]), array($alias_through[1],$alias_to_table[1]), $key);
-			}
-			$models[$rel_name]['order_by'][$key] = $direction;
-		}
-
-		return $models;
-	}
-
+	/**
+	 * Saves the relation
+	 *
+	 * @param Model $model_from
+	 * @param Model $models_to
+	 * @param $original_model_ids
+	 * @param $parent_saved
+	 * @param bool|null $cascade
+	 * @throws \FuelException
+	 */
 	public function save($model_from, $models_to, $original_model_ids, $parent_saved, $cascade)
 	{
 		if ( ! $parent_saved)
@@ -267,6 +425,7 @@ class ManyMany extends Relation
 		$original_model_ids === null and $original_model_ids = array();
 		$del_rels = $original_model_ids;
 
+		$order_through = 0;
 		foreach ($models_to as $key => $model_to)
 		{
 			if ( ! $model_to instanceof $this->model_to)
@@ -280,31 +439,57 @@ class ManyMany extends Relation
 				$model_to->save(false);
 			}
 
-			$current_model_id = $model_to ? $model_to->implode_pk($model_to) : null;
+			// Builds the primary keys of the table through
+			$through_pks = array();
+			reset($this->key_from);
+			foreach ($this->key_through_from as $pk)
+			{
+				$through_pks[$pk] = $model_from->{current($this->key_from)};
+				next($this->key_from);
+			}
 
-			// Check if the model was already assigned, if not INSERT relationships:
+			reset($this->key_to);
+			foreach ($this->key_through_to as $pk)
+			{
+				$through_pks[$pk] = $model_to->{current($this->key_to)};
+				next($this->key_to);
+			}
+
+			// Insert the relationships if not already assigned
+			$current_model_id = $model_to ? $model_to->implode_pk($model_to) : null;
 			if ( ! in_array($current_model_id, $original_model_ids))
 			{
-				$ids = array();
-				reset($this->key_from);
-				foreach ($this->key_through_from as $pk)
+				$values = $through_pks;
+
+				// Set order
+				if (!empty($this->key_through_order))
 				{
-					$ids[$pk] = $model_from->{current($this->key_from)};
-					next($this->key_from);
+					$values[$this->key_through_order] = $order_through;
 				}
 
-				reset($this->key_to);
-				foreach ($this->key_through_to as $pk)
-				{
-					$ids[$pk] = $model_to->{current($this->key_to)};
-					next($this->key_to);
-				}
+				// Insert the relation
+				\DB::insert($this->table_through)
+					->set($values)
+					->execute(call_user_func(array($model_from, 'connection')))
+				;
 
-				\DB::insert($this->table_through)->set($ids)->execute(call_user_func(array($model_from, 'connection')));
-				$original_model_ids[] = $current_model_id; // prevents inserting it a second time
+				// Prevents inserting it a second time
+				$original_model_ids[] = $current_model_id;
 			}
+
+			// Otherwise update the relationships if needed
 			else
 			{
+				// Set order
+				if (!empty($this->key_through_order))
+				{
+					\DB::update($this->table_through)
+						->value($this->key_through_order, $order_through)
+						->where($through_pks)
+						->execute(call_user_func(array($model_from, 'connection')))
+					;
+				}
+
 				// unset current model from from array of new relations
 				unset($del_rels[array_search($current_model_id, $original_model_ids)]);
 			}
@@ -322,6 +507,8 @@ class ManyMany extends Relation
 				$model_from->_relate($rel);
 				$model_from->freeze();
 			}
+
+			$order_through++;
 		}
 
 		// If any ids are left in $del_rels they are no longer assigned, DELETE the relationships:
@@ -357,6 +544,14 @@ class ManyMany extends Relation
 		}
 	}
 
+	/**
+	 * Deletes all relationship entries with cascade for the $model_from
+	 *
+	 * @param Model $model_from
+	 * @param array|Model $models_to
+	 * @param bool $parent_deleted
+	 * @param bool|null $cascade
+	 */
 	public function delete($model_from, $models_to, $parent_deleted, $cascade)
 	{
 		if ( ! $parent_deleted)
@@ -384,6 +579,11 @@ class ManyMany extends Relation
 		}
 	}
 
+	/**
+	 * Deletes all relationship entries for the $model_from
+	 *
+	 * @param $model_from
+	 */
 	public function delete_related($model_from)
 	{
 		// Delete all relationship entries for the model_from
@@ -395,5 +595,37 @@ class ManyMany extends Relation
 			next($this->key_from);
 		}
 		$query->execute(call_user_func(array($model_from, 'connection')));
+	}
+
+	/**
+	 * Return $field after setting/replacing the table alias
+	 *
+	 * @param $field
+	 * @param $alias_to
+	 * @return mixed|string
+	 */
+	public function getAliasedField($field, $alias_to)
+	{
+		if ($field instanceof \Fuel\Core\Database_Expression)
+		{
+			return $field;
+		}
+
+		if (strpos($field, '.') !== false)
+		{
+			// Replace the table name by the corresponding alias
+			$field = str_replace(
+				array($this->table_through.'.', call_user_func(array($this->model_to, 'table')).'.'),
+				array($alias_to.'_through.', $alias_to.'.'),
+				$field
+			);
+		}
+		else
+		{
+			// Set the alias on the field
+			$field = $alias_to.'.'.$field;
+		}
+
+		return $field;
 	}
 }


### PR DESCRIPTION
- Adds a new property "key_through_order" on a many_many relation that allows the ORM to populate the items order in the connection table.
- Unifies the implementation of the conditions (join_on, where_through, etc...) between the get() and the join() methods.
- Unifies the auto-replacement of table names by table aliases (was partially implemented on some conditions).

In theory there is no compatibility break.
