### PR TITLE
Refactor the many_many relation

### DIFF
--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -20,15 +20,15 @@ class ManyMany extends Relation
 
 	protected $key_to = array('id');
 
-    /**
-     * @var string   table name of model from
-     */
-    protected $table_from;
+	/**
+	 * @var string   table name of model from
+	 */
+	protected $table_from;
 
-    /**
-     * @var  string  table alias of model from
-     */
-    protected $alias_from;
+	/**
+	 * @var  string  table alias of model from
+	 */
+	protected $alias_from;
 
 	/**
 	 * @var  string  classname of model to use as connection
@@ -40,10 +40,10 @@ class ManyMany extends Relation
 	 */
 	protected $table_through;
 
-    /**
-     * @var  string  table alias of table to use as connection
-     */
-    protected $alias_through;
+	/**
+	 * @var  string  table alias of table to use as connection
+	 */
+	protected $alias_through;
 
 	/**
 	 * @var  string  foreign key of from model in connection table
@@ -55,42 +55,42 @@ class ManyMany extends Relation
 	 */
 	protected $key_through_to;
 
-    /**
-     * @var  string  table name of model to
-     */
-    protected $table_to;
+	/**
+	 * @var  string  table name of model to
+	 */
+	protected $table_to;
 
-    /**
-     * @var  string  table alias of model to
-     */
-    protected $alias_to;
+	/**
+	 * @var  string  table alias of model to
+	 */
+	protected $alias_to;
 
-    /**
-     * Initializes the relation specified by $name on the item $from
-     *
-     * @param string $from
-     * @param string $name
-     * @param array $config
-     * @throws \FuelException
-     */
-    public function __construct($from, $name, array $config)
+	/**
+	 * Initializes the relation specified by $name on the item $from
+	 *
+	 * @param string $from
+	 * @param string $name
+	 * @param array $config
+	 * @throws \FuelException
+	 */
+	public function __construct($from, $name, array $config)
 	{
 		$this->name        = $name;
 
-        // Sets the properties of the model from
+		// Sets the properties of the model from
 		$this->model_from = $from;
-        $this->table_from = call_user_func(array($this->model_from, 'table'));
+		$this->table_from = call_user_func(array($this->model_from, 'table'));
 		$this->key_from = array_key_exists('key_from', $config) ? (array) $config['key_from'] : $this->key_from;
 
-        // Sets the properties of the model to
-        $this->model_to = array_key_exists('model_to', $config) ? $config['model_to'] : $this->getRelationModel($name, $from);
-        $this->table_to = call_user_func(array($this->model_to, 'table'));
+		// Sets the properties of the model to
+		$this->model_to = array_key_exists('model_to', $config) ? $config['model_to'] : $this->getRelationModel($name, $from);
+		$this->table_to = call_user_func(array($this->model_to, 'table'));
 		$this->key_to = array_key_exists('key_to', $config) ? (array) $config['key_to'] : $this->key_to;
 
-        // Sets the conditions
+		// Sets the conditions
 		$this->conditions = array_key_exists('conditions', $config) ? (array) $config['conditions'] : array();
 
-        // Sets the properties of the table through
+		// Sets the properties of the table through
 		if (!empty($config['table_through']))
 		{
 			$this->table_through = $config['table_through'];
@@ -106,13 +106,13 @@ class ManyMany extends Relation
 			? (array) $config['key_through_from'] : (array) \Inflector::foreign_key($this->model_from);
 		$this->key_through_to = !empty($config['key_through_to'])
 			? (array) $config['key_through_to'] : (array) \Inflector::foreign_key($this->model_to);
-        $this->key_through_order = (string) \Arr::get($config, 'key_through_order');
+		$this->key_through_order = (string) \Arr::get($config, 'key_through_order');
 
-        // Sets the cascade properties
+		// Sets the cascade properties
 		$this->cascade_save = array_key_exists('cascade_save', $config) ? $config['cascade_save'] : $this->cascade_save;
 		$this->cascade_delete = array_key_exists('cascade_delete', $config) ? $config['cascade_delete'] : $this->cascade_delete;
 
-        // Checks if the model to exists
+		// Checks if the model to exists
 		if (!class_exists($this->model_to))
 		{
 			throw new \FuelException('Related model not found by Many_Many relation "'.$this->name.'": '.$this->model_to);
@@ -236,8 +236,8 @@ class ManyMany extends Relation
 		foreach (\Arr::get($conditions, 'where', array()) as $key => $condition)
 		{
 			is_array($condition) or $condition = array($key, '=', $condition);
-            // @todo handles the special case of a "where" condition with an alias on the model from when there is no table from (eg. when the get() is called)
-            $condition[0] = $this->getAliasedField($condition[0]);
+			// @todo handles the special case of a "where" condition with an alias on the model from when there is no table from (eg. when the get() is called)
+			$condition[0] = $this->getAliasedField($condition[0]);
 			$query->where($condition);
 		}
 
@@ -273,7 +273,7 @@ class ManyMany extends Relation
 	}
 
 	/**
-     * Gets the properties to join the related items on a query
+	 * Gets the properties to join the related items on a query
 	 *
 	 * @param $alias_from
 	 * @param $rel_name
@@ -284,7 +284,7 @@ class ManyMany extends Relation
 	public function join($alias_from, $rel_name, $alias_to_nr, $conditions = array())
 	{
 		$this->alias_to = 't'.$alias_to_nr;
-        $this->alias_from = $alias_from;
+		$this->alias_from = $alias_from;
 		$this->alias_through = $this->alias_to.'_through';
 
 		// Merges the conditions of the relation with the specific conditions
@@ -700,10 +700,10 @@ class ManyMany extends Relation
 
 		if (strpos($field, '.') !== false)
 		{
-            $replaces = array(
-                array($this->table_to.'.'),
-                array($this->alias_to.'.'),
-            );
+			$replaces = array(
+				array($this->table_to.'.'),
+				array($this->alias_to.'.'),
+			);
 			if ($this->table_through && $this->alias_through)
 			{
 				$replaces[0][] = $this->table_through.'.';
@@ -727,31 +727,31 @@ class ManyMany extends Relation
 		return $field;
 	}
 
-    /**
-     * Gets the relation name from a relation path
-     *
-     * @param $path
-     * @return string
-     */
-    public function getRelationName($path)
+	/**
+	 * Gets the relation name from a relation path
+	 *
+	 * @param $path
+	 * @return string
+	 */
+	public function getRelationName($path)
 	{
-        // Removes the path before the relation name
-        if (strrpos($path, '.') !== false)
+		// Removes the path before the relation name
+		if (strrpos($path, '.') !== false)
 		{
-            $path = substr($path, strrpos($path, '.') + 1);
-        }
-        return $path;
-    }
+			$path = substr($path, strrpos($path, '.') + 1);
+		}
+		return $path;
+	}
 
-    /**
-     * Gets the model of the $relation_name on the item $from
-     *
-     * @param $relation_name
-     * @param $from
-     * @return string
-     */
-    protected function getRelationModel($relation_name, $from)
+	/**
+	 * Gets the model of the $relation_name on the item $from
+	 *
+	 * @param $relation_name
+	 * @param $from
+	 * @return string
+	 */
+	protected function getRelationModel($relation_name, $from)
 	{
-        return \Inflector::get_namespace($from).'Model_'.\Inflector::classify($relation_name);
-    }
+		return \Inflector::get_namespace($from).'Model_'.\Inflector::classify($relation_name);
+	}
 }

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -101,17 +101,17 @@ class ManyMany extends Relation
 		$query = call_user_func(array($this->model_to, 'query'));
 
 		// Builds the join on the table through
-		if (!$this->_query_build_join($query, $conditions, $alias_to, $from)) {
+		if (!$this->_build_query_join($query, $conditions, $alias_to, $from)) {
 			return array();
 		}
 
 		// Builds the where conditions
-		if (!$this->_query_build_where($query, $conditions, $alias_to, $from)) {
+		if (!$this->_build_query_where($query, $conditions, $alias_to, $from)) {
 			return array();
 		}
 
 		// Builds the order_by conditions
-		if (!$this->_query_build_orderby($query, $conditions, $alias_to, $from)) {
+		if (!$this->_build_query_orderby($query, $conditions, $alias_to, $from)) {
 			return array();
 		}
 
@@ -127,7 +127,7 @@ class ManyMany extends Relation
 	 * @param $model_from
 	 * @return array
 	 */
-	protected function _query_build_join($query, $conditions, $alias_to, $model_from)
+	protected function _build_query_join($query, $conditions, $alias_to, $model_from)
 	{
 		$join = array(
 			'table'      => array($this->table_through, $alias_to.'_through'),
@@ -167,7 +167,7 @@ class ManyMany extends Relation
 	 * @param $model_from
 	 * @return bool
 	 */
-	protected function _query_build_where($query, $conditions, $alias_to, $model_from)
+	protected function _build_query_where($query, $conditions, $alias_to, $model_from)
 	{
 		// Creates the native conditions on the query
 		reset($this->key_from);
@@ -209,7 +209,7 @@ class ManyMany extends Relation
 	 * @param $model_from
 	 * @return bool
 	 */
-	protected function _query_build_orderby($query, $conditions, $alias_to, $model_from)
+	protected function _build_query_orderby($query, $conditions, $alias_to, $model_from)
 	{
 		// Creates the custom order_by conditions on the query
 		foreach (\Arr::get($conditions, 'order_by', array()) as $field => $direction)
@@ -272,31 +272,31 @@ class ManyMany extends Relation
 		);
 
 		// Builds the join conditions on the table_through
-		if (!$this->_join_build_join_through($models, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_through($models, $rel_name, $alias_to, $alias_from, $conditions))
 		{
 			return array();
 		}
 
 		// Builds the join conditions on the model_to
-		if (!$this->_join_build_join_to($models, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_to($models, $rel_name, $alias_to, $alias_from, $conditions))
 		{
 			return array();
 		}
 
 		// Builds the where conditions on the table_through
-		if (!$this->_join_build_where_through($models, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_where_through($models, $rel_name, $alias_to, $alias_from, $conditions))
 		{
 			return array();
 		}
 
 		// Builds the where conditions on the model_to
-		if (!$this->_join_build_where_to($models, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_where_to($models, $rel_name, $alias_to, $alias_from, $conditions))
 		{
 			return array();
 		}
 
 		// Builds the order_by conditions
-		if (!$this->_join_build_orderby($models, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_orderby($models, $rel_name, $alias_to, $alias_from, $conditions))
 		{
 			return array();
 		}
@@ -314,7 +314,7 @@ class ManyMany extends Relation
 	 * @param $conditions
 	 * @return bool
 	 */
-	protected function _join_build_join_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	protected function _build_join_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		reset($this->key_from);
 		foreach ($this->key_through_from as $key)
@@ -336,7 +336,7 @@ class ManyMany extends Relation
 	 * @param $conditions
 	 * @return bool
 	 */
-	protected function _join_build_join_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	protected function _build_join_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		reset($this->key_to);
 		foreach ($this->key_through_to as $key)
@@ -358,7 +358,7 @@ class ManyMany extends Relation
 	 * @param $conditions
 	 * @return bool
 	 */
-	protected function _join_build_where_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	protected function _build_join_where_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		// Creates the custom conditions on the table_through join
 		foreach (\Arr::get($conditions, 'through_where', array()) as $key => $condition)
@@ -382,7 +382,7 @@ class ManyMany extends Relation
 	 * @param $conditions
 	 * @return bool
 	 */
-	protected function _join_build_where_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	protected function _build_join_where_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		// Creates the custom conditions on the model_to join
 		foreach (\Arr::get($conditions, array('where', 'join_on')) as $where)
@@ -409,7 +409,7 @@ class ManyMany extends Relation
 	 * @param $conditions
 	 * @return bool
 	 */
-	protected function _join_build_orderby(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	protected function _build_join_orderby(&$models, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		// Builds the order_by conditions
 		foreach (\Arr::get($conditions, 'order_by', array()) as $key => $direction)

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -81,52 +81,135 @@ class ManyMany extends Relation
 		$this->model_to = get_real_class($this->model_to);
 	}
 
+	/**
+	 * Gets the related items for the item $from
+	 *
+	 * @param Model $from
+	 * @param array $conditions
+	 * @return array|object
+	 */
 	public function get(Model $from, array $conditions = array())
 	{
-		// Create the query on the model_through
+		$alias_to = 't0';
+
+		// Merges the conditions of the relation with the specific conditions
+		$conditions = \Arr::merge($this->conditions, $conditions);
+
+		// Creates the query on the model_through
 		$query = call_user_func(array($this->model_to, 'query'));
 
-		// set the model_from's keys as where conditions for the model_through
-		$join = array(
-				'table'      => array($this->table_through, 't0_through'),
-				'join_type'  => null,
-				'join_on'    => array(),
-				'columns'    => $this->select_through('t0_through')
-		);
-
-		reset($this->key_from);
-		foreach ($this->key_through_from as $key)
-		{
-			if ($from->{current($this->key_from)} === null)
-			{
-				return array();
-			}
-			$query->where('t0_through.'.$key, $from->{current($this->key_from)});
-			next($this->key_from);
+		// Builds the join on the table through
+		if (!$this->_query_build_join($query, $conditions, $alias_to, $from)) {
+			return array();
 		}
 
+		// Builds the where conditions
+		if (!$this->_query_build_where($query, $conditions, $alias_to, $from)) {
+			return array();
+		}
+
+		// Builds the order_by conditions
+		if (!$this->_query_build_orderby($query, $conditions, $alias_to, $from)) {
+			return array();
+		}
+
+		return $query->get();
+	}
+
+	/**
+	 * Builds the join on the table through for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return array
+	 */
+	protected function _query_build_join($query, $conditions, $alias_to, $model_from)
+	{
+		$join = array(
+			'table'      => array($this->table_through, $alias_to.'_through'),
+			'join_type'  => null,
+			'join_on'    => array(),
+			'columns'    => $this->select_through($alias_to.'_through')
+		);
+
+		// Creates the native conditions on the join
 		reset($this->key_to);
 		foreach ($this->key_through_to as $key)
 		{
-			$join['join_on'][] = array('t0_through.'.$key, '=', 't0.'.current($this->key_to));
+			$join['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
 			next($this->key_to);
 		}
 
-        foreach (\Arr::get($this->conditions, 'through_where', array()) as $key => $condition)
-        {
-            is_array($condition) or $condition = array($key, '=', $condition);
-            $condition[0] = 't0_through.'.$condition[0];
-            $query->where($condition);
-        }
+		// Creates the custom conditions on the join
+		foreach (\Arr::get($conditions, 'join_on', array()) as $key => $condition) {
+			is_array($condition) or $condition = array($key, '=', $condition);
+			reset($condition);
+			$condition[key($condition)] = $alias_to.'_through.'.current($condition);
+			$join['join_on'][] = $condition;
+		}
 
-        $conditions = \Arr::merge($this->conditions, $conditions);
+		// Creates the join on the query
+		$query->_join($join);
 
-        foreach (\Arr::get($conditions, 'where', array()) as $key => $condition)
+		return true;
+	}
+
+	/**
+	 * Builds the where conditions for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return bool
+	 */
+	protected function _query_build_where($query, $conditions, $alias_to, $model_from)
+	{
+		// Creates the native conditions on the query
+		reset($this->key_from);
+		foreach ($this->key_through_from as $key)
+		{
+			if ($model_from->{current($this->key_from)} === null)
+			{
+				return false;
+			}
+			$query->where($alias_to.'_through.'.$key, $model_from->{current($this->key_from)});
+			next($this->key_from);
+		}
+
+		// Creates the custom conditions related to the table through on the query
+		foreach (\Arr::get($conditions, 'through_where', array()) as $key => $condition)
 		{
 			is_array($condition) or $condition = array($key, '=', $condition);
+			$condition[0] = $alias_to.'_through.'.$condition[0];
 			$query->where($condition);
 		}
 
+		// Creates the custom conditions on the query
+		foreach (\Arr::get($conditions, 'where', array()) as $key => $condition)
+		{
+			is_array($condition) or $condition = array($key, '=', $condition);
+			$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+			$query->where($condition);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the order_by conditions for a query
+	 *
+	 * @param $query
+	 * @param $conditions
+	 * @param $alias_to
+	 * @param $model_from
+	 * @return bool
+	 */
+	protected function _query_build_orderby($query, $conditions, $alias_to, $model_from)
+	{
+		// Creates the custom order_by conditions on the query
 		foreach (\Arr::get($conditions, 'order_by', array()) as $field => $direction)
 		{
 			if (is_numeric($field))
@@ -135,15 +218,213 @@ class ManyMany extends Relation
 			}
 			else
 			{
+				$field = $this->getAliasedField($field, $alias_to);
 				$query->order_by($field, $direction);
 			}
 		}
 
-		$query->_join($join);
-
-		return $query->get();
+		return true;
 	}
 
+	/**
+	 * Gets the properties to join the related items for a query
+	 *
+	 * @param $alias_from
+	 * @param $rel_name
+	 * @param $alias_to_nr
+	 * @param array $conditions
+	 * @return array
+	 */
+	public function join($alias_from, $rel_name, $alias_to_nr, $conditions = array())
+	{
+		$alias_to = 't'.$alias_to_nr;
+
+		// Merges the conditions of the relation with the specific conditions
+		$conditions = \Arr::merge($this->conditions, $conditions);
+
+		// Creates the joins to the model_to
+		$models = array(
+			$rel_name.'_through' => array(
+				'model'        => null,
+				'connection'   => call_user_func(array($this->model_to, 'connection',)),
+				'table'        => array($this->table_through, $alias_to.'_through'),
+				'primary_key'  => null,
+				'join_type'    => \Arr::get($conditions, 'join_type', 'left'),
+				'join_on'      => array(),
+				'columns'      => $this->select_through($alias_to.'_through'),
+				'rel_name'     => $this->model_through,
+				'relation'     => $this
+			),
+			$rel_name => array(
+				'model'        => $this->model_to,
+				'connection'   => call_user_func(array($this->model_to, 'connection')),
+				'table'        => array(call_user_func(array($this->model_to, 'table')), $alias_to),
+				'primary_key'  => call_user_func(array($this->model_to, 'primary_key')),
+				'join_type'    => \Arr::get($conditions, 'join_type', 'left'),
+				'join_on'      => array(),
+				'columns'      => $this->select($alias_to),
+				'rel_name'     => strpos($rel_name, '.') ? substr($rel_name, strrpos($rel_name, '.') + 1) : $rel_name,
+				'relation'     => $this,
+				'where'        => \Arr::get($conditions, 'where', array()),
+			)
+		);
+
+		// Builds the join conditions on the table_through
+		if (!$this->_join_build_join_through($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the join conditions on the model_to
+		if (!$this->_join_build_join_to($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the where conditions on the table_through
+		if (!$this->_join_build_where_through($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the where conditions on the model_to
+		if (!$this->_join_build_where_to($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		// Builds the order_by conditions
+		if (!$this->_join_build_orderby($models, $rel_name, $alias_to, $alias_from, $conditions))
+		{
+			return array();
+		}
+
+		return $models;
+	}
+
+	/**
+	 * Builds the conditions for the table_through join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_join_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		reset($this->key_from);
+		foreach ($this->key_through_from as $key)
+		{
+			$models[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'_through.'.$key);
+			next($this->key_from);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the conditions for the model_to join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_join_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		reset($this->key_to);
+		foreach ($this->key_through_to as $key)
+		{
+			$models[$rel_name]['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
+			next($this->key_to);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the where conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_where_through(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Creates the custom conditions on the table_through join
+		foreach (\Arr::get($conditions, 'through_where', array()) as $key => $condition)
+		{
+			! is_array($condition) and $condition = array($key, '=', $condition);
+			is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
+			$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+			$models[$rel_name.'_through']['join_on'][] = $condition;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the where conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_where_to(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Creates the custom conditions on the model_to join
+		foreach (\Arr::get($conditions, array('where', 'join_on')) as $where)
+		{
+			foreach ($where as $key => $condition)
+			{
+				! is_array($condition) and $condition = array($key, '=', $condition);
+				is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
+				$condition[0] = $this->getAliasedField($condition[0], $alias_to);
+				$models[$rel_name]['join_on'][] = $condition;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the order_by conditions for a join
+	 *
+	 * @param $models
+	 * @param $rel_name
+	 * @param $alias_to
+	 * @param $alias_from
+	 * @param $conditions
+	 * @return bool
+	 */
+	protected function _join_build_orderby(&$models, $rel_name, $alias_to, $alias_from, $conditions)
+	{
+		// Builds the order_by conditions
+		foreach (\Arr::get($conditions, 'order_by', array()) as $key => $direction)
+		{
+			$key = $this->getAliasedField($key, $alias_to);
+			$models[$rel_name]['order_by'][$key] = $direction;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the columns to select through a table
+	 *
+	 * @param $table
+	 * @return array
+	 */
 	public function select_through($table)
 	{
 		foreach ($this->key_through_to as $to)
@@ -158,100 +439,16 @@ class ManyMany extends Relation
 		return $properties;
 	}
 
-	public function join($alias_from, $rel_name, $alias_to_nr, $conditions = array())
-	{
-		$alias_to = 't'.$alias_to_nr;
-
-		$alias_through = array($this->table_through, $alias_to.'_through');
-		$alias_to_table = array(call_user_func(array($this->model_to, 'table')), $alias_to);
-
-		$models = array(
-			$rel_name.'_through' => array(
-				'model'        => null,
-				'connection'   => call_user_func(array($this->model_to, 'connection')),
-				'table'        => $alias_through,
-				'primary_key'  => null,
-				'join_type'    => \Arr::get($conditions, 'join_type') ?: \Arr::get($this->conditions, 'join_type', 'left'),
-				'join_on'      => array(),
-				'columns'      => $this->select_through($alias_to.'_through'),
-				'rel_name'     => $this->model_through,
-				'relation'     => $this
-			),
-			$rel_name => array(
-				'model'        => $this->model_to,
-				'connection'   => call_user_func(array($this->model_to, 'connection')),
-				'table'        => $alias_to_table,
-				'primary_key'  => call_user_func(array($this->model_to, 'primary_key')),
-				'join_type'    => \Arr::get($conditions, 'join_type') ?: \Arr::get($this->conditions, 'join_type', 'left'),
-				'join_on'      => array(),
-				'columns'      => $this->select($alias_to),
-				'rel_name'     => strpos($rel_name, '.') ? substr($rel_name, strrpos($rel_name, '.') + 1) : $rel_name,
-				'relation'     => $this,
-				'where'        => \Arr::get($conditions, 'where', array()),
-			)
-		);
-
-		reset($this->key_from);
-		foreach ($this->key_through_from as $key)
-		{
-			$models[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'_through.'.$key);
-			next($this->key_from);
-		}
-
-		reset($this->key_to);
-		foreach ($this->key_through_to as $key)
-		{
-			$models[$rel_name]['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
-			next($this->key_to);
-		}
-
-        foreach (array(\Arr::get($this->conditions, 'through_where', array()), \Arr::get($conditions, 'through_where', array())) as $c)
-        {
-            foreach ($c as $key => $condition)
-            {
-                ! is_array($condition) and $condition = array($key, '=', $condition);
-                if ( ! $condition[0] instanceof \Fuel\Core\Database_Expression and strpos($condition[0], '.') === false)
-                {
-                    $condition[0] = $alias_to.'_through'.'.'.$condition[0];
-                }
-                is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
-
-                $models[$rel_name.'_through']['join_on'][] = $condition;
-            }
-        }
-
-		foreach (array(\Arr::get($this->conditions, 'where', array()), \Arr::get($conditions, 'join_on', array())) as $c)
-		{
-			foreach ($c as $key => $condition)
-			{
-				! is_array($condition) and $condition = array($key, '=', $condition);
-				if ( ! $condition[0] instanceof \Fuel\Core\Database_Expression and strpos($condition[0], '.') === false)
-				{
-					$condition[0] = $alias_to.'.'.$condition[0];
-				}
-				is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $models[$rel_name]['connection']);
-
-				$models[$rel_name]['join_on'][] = $condition;
-			}
-		}
-
-		$order_by = \Arr::get($conditions, 'order_by') ?: \Arr::get($this->conditions, 'order_by', array());
-		foreach ($order_by as $key => $direction)
-		{
-			if ( ! $key instanceof \Fuel\Core\Database_Expression and strpos($key, '.') === false)
-			{
-				$key = $alias_to.'.'.$key;
-			}
-			else
-			{
-				$key = str_replace(array($alias_through[0],$alias_to_table[0]), array($alias_through[1],$alias_to_table[1]), $key);
-			}
-			$models[$rel_name]['order_by'][$key] = $direction;
-		}
-
-		return $models;
-	}
-
+	/**
+	 * Saves the relation
+	 *
+	 * @param Model $model_from
+	 * @param Model $models_to
+	 * @param $original_model_ids
+	 * @param $parent_saved
+	 * @param bool|null $cascade
+	 * @throws \FuelException
+	 */
 	public function save($model_from, $models_to, $original_model_ids, $parent_saved, $cascade)
 	{
 		if ( ! $parent_saved)
@@ -267,6 +464,7 @@ class ManyMany extends Relation
 		$original_model_ids === null and $original_model_ids = array();
 		$del_rels = $original_model_ids;
 
+		$order_through = 0;
 		foreach ($models_to as $key => $model_to)
 		{
 			if ( ! $model_to instanceof $this->model_to)
@@ -280,29 +478,36 @@ class ManyMany extends Relation
 				$model_to->save(false);
 			}
 
-			$current_model_id = $model_to ? $model_to->implode_pk($model_to) : null;
+			// Builds the primary keys of the table through
+			$through_pks = array();
+			reset($this->key_from);
+			foreach ($this->key_through_from as $pk)
+			{
+				$through_pks[$pk] = $model_from->{current($this->key_from)};
+				next($this->key_from);
+			}
 
-			// Check if the model was already assigned, if not INSERT relationships:
+			reset($this->key_to);
+			foreach ($this->key_through_to as $pk)
+			{
+				$through_pks[$pk] = $model_to->{current($this->key_to)};
+				next($this->key_to);
+			}
+
+			// Insert the relationships if not already assigned
+			$current_model_id = $model_to ? $model_to->implode_pk($model_to) : null;
 			if ( ! in_array($current_model_id, $original_model_ids))
 			{
-				$ids = array();
-				reset($this->key_from);
-				foreach ($this->key_through_from as $pk)
-				{
-					$ids[$pk] = $model_from->{current($this->key_from)};
-					next($this->key_from);
-				}
-
-				reset($this->key_to);
-				foreach ($this->key_through_to as $pk)
-				{
-					$ids[$pk] = $model_to->{current($this->key_to)};
-					next($this->key_to);
-				}
-
-				\DB::insert($this->table_through)->set($ids)->execute(call_user_func(array($model_from, 'connection')));
-				$original_model_ids[] = $current_model_id; // prevents inserting it a second time
+				// Insert the relation
+				\DB::insert($this->table_through)
+					->set($through_pks)
+					->execute(call_user_func(array($model_from, 'connection')))
+				;
+				// Prevents inserting it a second time
+				$original_model_ids[] = $current_model_id;
 			}
+
+			// Otherwise update the relationships if needed
 			else
 			{
 				// unset current model from from array of new relations
@@ -322,6 +527,8 @@ class ManyMany extends Relation
 				$model_from->_relate($rel);
 				$model_from->freeze();
 			}
+
+			$order_through++;
 		}
 
 		// If any ids are left in $del_rels they are no longer assigned, DELETE the relationships:
@@ -357,6 +564,14 @@ class ManyMany extends Relation
 		}
 	}
 
+	/**
+	 * Deletes all relationship entries with cascade for the $model_from
+	 *
+	 * @param Model $model_from
+	 * @param array|Model $models_to
+	 * @param bool $parent_deleted
+	 * @param bool|null $cascade
+	 */
 	public function delete($model_from, $models_to, $parent_deleted, $cascade)
 	{
 		if ( ! $parent_deleted)
@@ -384,6 +599,11 @@ class ManyMany extends Relation
 		}
 	}
 
+	/**
+	 * Deletes all relationship entries for the $model_from
+	 *
+	 * @param $model_from
+	 */
 	public function delete_related($model_from)
 	{
 		// Delete all relationship entries for the model_from
@@ -395,5 +615,37 @@ class ManyMany extends Relation
 			next($this->key_from);
 		}
 		$query->execute(call_user_func(array($model_from, 'connection')));
+	}
+
+	/**
+	 * Return $field after setting/replacing the table alias
+	 *
+	 * @param $field
+	 * @param $alias_to
+	 * @return mixed|string
+	 */
+	public function getAliasedField($field, $alias_to)
+	{
+		if ($field instanceof \Fuel\Core\Database_Expression)
+		{
+			return $field;
+		}
+
+		if (strpos($field, '.') !== false)
+		{
+			// Replace the table name by the corresponding alias
+			$field = str_replace(
+				array($this->table_through.'.', call_user_func(array($this->model_to, 'table')).'.'),
+				array($alias_to.'_through.', $alias_to.'.'),
+				$field
+			);
+		}
+		else
+		{
+			// Set the alias on the field
+			$field = $alias_to.'.'.$field;
+		}
+
+		return $field;
 	}
 }

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -196,7 +196,7 @@ class ManyMany extends Relation
 		{
 			is_array($condition) or $condition = array($key, '=', $condition);
 			reset($condition);
-			$condition[key($condition)] = $this->alias_through.'.'.current($condition);
+			$condition[key($condition)] = $this->getAliasedField(current($condition), $this->alias_through);
 			$join['join_on'][] = $condition;
 		}
 

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -272,13 +272,13 @@ class ManyMany extends Relation
 		);
 
 		// Builds the join conditions on the table_through
-		if (!$this->_build_join_through($joins, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_through($joins, $rel_name, $alias_to.'_through', $alias_from, $conditions))
 		{
 			return array();
 		}
 
 		// Builds the join conditions on the model_to
-		if (!$this->_build_join_to($joins, $rel_name, $alias_to, $alias_from, $conditions))
+		if (!$this->_build_join_to($joins, $rel_name, $alias_to, $alias_to.'_through', $conditions))
 		{
 			return array();
 		}
@@ -319,7 +319,7 @@ class ManyMany extends Relation
 		reset($this->key_from);
 		foreach ($this->key_through_from as $key)
 		{
-			$joins[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'_through.'.$key);
+			$joins[$rel_name.'_through']['join_on'][] = array($alias_from.'.'.current($this->key_from), '=', $alias_to.'.'.$key);
 			next($this->key_from);
 		}
 
@@ -341,7 +341,7 @@ class ManyMany extends Relation
 		reset($this->key_to);
 		foreach ($this->key_through_to as $key)
 		{
-			$joins[$rel_name]['join_on'][] = array($alias_to.'_through.'.$key, '=', $alias_to.'.'.current($this->key_to));
+			$joins[$rel_name]['join_on'][] = array($alias_from.'.'.$key, '=', $alias_to.'.'.current($this->key_to));
 			next($this->key_to);
 		}
 
@@ -385,7 +385,7 @@ class ManyMany extends Relation
 	protected function _build_join_where_to(&$joins, $rel_name, $alias_to, $alias_from, $conditions)
 	{
 		// Creates the custom conditions on the model_to join
-		foreach (\Arr::get($conditions, array('where', 'join_on')) as $where)
+		foreach (\Arr::get($conditions, array('where', 'join_on'), array()) as $where)
 		{
 			foreach ($where as $key => $condition)
 			{

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -726,7 +726,7 @@ class ManyMany extends Relation
 		else
 		{
 			// Set the alias on the field
-            $field = ($defaut_alias ? $defaut_alias : $this->alias_to).'.'.$field;
+			$field = ($defaut_alias ? $defaut_alias : $this->alias_to).'.'.$field;
 		}
 
 		return $field;

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -242,7 +242,7 @@ class ManyMany extends Relation
 		{
 			is_array($condition) or $condition = array($key, '=', $condition);
 			// @todo handles the special case of a "where" condition with an alias on the model from when there is no table from (eg. when the get() is called)
-			$condition[0] = $this->getAliasedField($condition[0]);
+			$condition[0] = $this->getAliasedField($condition[0], $alias_to);
 			$query->where($condition);
 		}
 
@@ -269,7 +269,7 @@ class ManyMany extends Relation
 			}
 			else
 			{
-				$field = $this->getAliasedField($field);
+				$field = $this->getAliasedField($field, $alias_to);
 				$query->order_by($field, $direction);
 			}
 		}
@@ -416,7 +416,7 @@ class ManyMany extends Relation
 		{
 			!is_array($condition) and $condition = array($key, '=', $condition);
 			is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $joins[$rel_name]['connection']);
-			$condition[0] = $this->getAliasedField($condition[0]);
+			$condition[0] = $this->getAliasedField($condition[0], $this->alias_through);
 			$joins[$rel_name.'_through']['join_on'][] = $condition;
 		}
 
@@ -442,7 +442,7 @@ class ManyMany extends Relation
 			{
 				!is_array($condition) and $condition = array($key, '=', $condition);
 				is_string($condition[2]) and $condition[2] = \Db::quote($condition[2], $joins[$rel_name]['connection']);
-				$condition[0] = $this->getAliasedField($condition[0]);
+				$condition[0] = $this->getAliasedField($condition[0], $alias_to);
 				$joins[$rel_name]['join_on'][] = $condition;
 			}
 		}
@@ -465,7 +465,7 @@ class ManyMany extends Relation
 		// Builds the order_by conditions
 		foreach (\Arr::get($conditions, 'order_by', array()) as $key => $direction)
 		{
-			$key = $this->getAliasedField($key);
+			$key = $this->getAliasedField($key, $alias_to);
 			$joins[$rel_name]['order_by'][$key] = $direction;
 		}
 
@@ -693,10 +693,10 @@ class ManyMany extends Relation
 	 * Return $field after setting/replacing the table alias
 	 *
 	 * @param $field
-	 * @param $no_relation_from
+	 * @param null|string $defaut_alias
 	 * @return mixed|string
 	 */
-	public function getAliasedField($field)
+	public function getAliasedField($field, $defaut_alias = null)
 	{
 		if ($field instanceof \Fuel\Core\Database_Expression)
 		{
@@ -726,7 +726,7 @@ class ManyMany extends Relation
 		else
 		{
 			// Set the alias on the field
-			$field = $this->alias_to.'.'.$field;
+            $field = ($defaut_alias ? $defaut_alias : $this->alias_to).'.'.$field;
 		}
 
 		return $field;

--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -56,6 +56,11 @@ class ManyMany extends Relation
 	protected $key_through_to;
 
 	/**
+	 * @var  string  order key on the connection table
+	 */
+	protected $key_through_order;
+
+	/**
 	 * @var  string  table name of model to
 	 */
 	protected $table_to;


### PR DESCRIPTION
#4 was merged accidentally and was not totally finished. I reverted the merge and created this new PR.

What this PR does :
- Unifies the implementation of the conditions (join_on, where_through, etc...) between the get() and the join() methods.
- Unifies the auto-replacement of table names by table aliases (was partially implemented on some conditions).
- Adds a new property "key_through_order" on a many_many relation that allows the ORM to populate the items order in the connection table.

There should be no compatibility break.
