### PR TITLE
HasMany delete orphan child

### DIFF
--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -214,10 +214,10 @@ class HasMany extends Relation
 			{
 				$frozen = $obj->frozen(); // only unfreeze/refreeze when it was frozen
 				$frozen and $obj->unfreeze();
-                $model_from->unfreeze();
-                // Delete the related object
-                $obj->delete();
-                $model_from->freeze();
+				$model_from->unfreeze();
+				// Delete the related object
+				$obj->delete();
+				$model_from->freeze();
 			}
 		}
 

--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -214,14 +214,10 @@ class HasMany extends Relation
 			{
 				$frozen = $obj->frozen(); // only unfreeze/refreeze when it was frozen
 				$frozen and $obj->unfreeze();
-				foreach ($this->key_to as $fk)
-				{
-					$obj->{$fk} = null;
-				}
-				$frozen and $obj->freeze();
-
-				// cascading this change won't work here, save just the object with cascading switched off
-				$obj->save(false);
+                $model_from->unfreeze();
+                // Delete the related object
+                $obj->delete();
+                $model_from->freeze();
 			}
 		}
 


### PR DESCRIPTION
I made a change to the HasMany relation behaviour, at the time the relationship only set the foreign key to null, leaving a orphan item in the model.

With this modification, we clean completely the orphaned item, and thus trigger the delete, and the cascading deletes on the child.

This prevents a lot of bugs such as 

``` php
$parent->children = array($child);
$parent->save(); // One row in db

$parent->children = array();
$parent->save(); // Still one row in db without the bugfix
```

And moreso if the children element has other relations which won't be clear by the current behaviour.

``` php
$children->sub_children = array($subchildren);
$parent->children = array($child);
$parent->save(); // One row in db

$parent->children = array();
$parent->save(); // Still one row in db without the bugfix

$subchildren->parent; //  Find a bastard item without parent.
```
