### PR TITLE
Fix specific conditions on the query

### DIFF
--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -290,6 +290,10 @@ class ManyMany extends Relation
 		$this->alias_from = $alias_from;
 		$this->alias_through = $this->alias_to.'_through';
 
+		// Extracts the where conditions that should be applied on the whole query
+		$where = (array) \Arr::get($conditions, 'where', array());
+		\Arr::delete($conditions, 'where');
+
 		// Merges the conditions of the relation with the specific conditions
 		$conditions = \Arr::merge($this->conditions, $conditions);
 
@@ -316,7 +320,7 @@ class ManyMany extends Relation
 				'columns'      => $this->select($this->alias_to),
 				'rel_name'     => $this->getRelationName($rel_name),
 				'relation'     => $this,
-				'where'        => array(),
+				'where'        => $where, // Theses conditions will be applied on the whole query
 			)
 		);
 


### PR DESCRIPTION
To avoid breaking existing code, the specific "where" conditions are now applied on the query rather than on the join (it was the original behaviour before the refactoring).

This bug was discovered while filtering the news (with the noviusos_news app) on a category. The inspector adds a "where" condition in the relation's specific conditions, using the relation name as the table name, but the Many_Many class won't replace the relation name with the corresponding alias (this behaviour only works with a full table name).
