### PR TITLE
Fix substr on unicode string

### DIFF
--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -243,9 +243,9 @@ class Observer_Typing
 		if (array_key_exists('character_maximum_length', $settings))
 		{
 			$length  = intval($settings['character_maximum_length']);
-			if ($length > 0 and strlen($var) > $length)
+			if ($length > 0 and mb_strlen($var) > $length)
 			{
-				$var = substr($var, 0, $length);
+				$var = mb_substr($var, 0, $length);
 			}
 		}
 


### PR DESCRIPTION
This replaces `substr` by `mb_substr`.

My specific case happened with a `varchar(250)` field, and a string that was longer. The 250th and 251th bytes of the string were an UTF-8 non-breakable space (0xC2A0).

Since C2 is a control character that can't exist alone, this made everything using this string crash thereafter (including debugging tools).